### PR TITLE
Add ARIA labels and pressed states to icon-only buttons

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -177,7 +177,7 @@ export default function Home() {
                         <button
                           onClick={() => toggleFavorite(show.id)}
                           className="p-2 rounded-lg hover:bg-purple-600/20 transition-colors"
-                          aria-label="Add to favorites"
+                          aria-label={favorites.has(show.id) ? "Remove from favorites" : "Add to favorites"}
                           aria-pressed={favorites.has(show.id)}
                         >
                           {favorites.has(show.id) ? (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -177,6 +177,8 @@ export default function Home() {
                         <button
                           onClick={() => toggleFavorite(show.id)}
                           className="p-2 rounded-lg hover:bg-purple-600/20 transition-colors"
+                          aria-label="Add to favorites"
+                          aria-pressed={favorites.has(show.id)}
                         >
                           {favorites.has(show.id) ? (
                             <HeartSolidIcon className="h-5 w-5 text-red-400" />

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -282,7 +282,7 @@ function SearchContent() {
                           <button
                             onClick={() => toggleFavorite(show.id)}
                             className="p-2 rounded-lg hover:bg-purple-600/20 transition-colors"
-                            aria-label="Add to favorites"
+                            aria-label={favorites.has(show.id) ? "Remove from favorites" : "Add to favorites"}
                             aria-pressed={favorites.has(show.id)}
                           >
                             {favorites.has(show.id) ? (

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -282,6 +282,8 @@ function SearchContent() {
                           <button
                             onClick={() => toggleFavorite(show.id)}
                             className="p-2 rounded-lg hover:bg-purple-600/20 transition-colors"
+                            aria-label="Add to favorites"
+                            aria-pressed={favorites.has(show.id)}
                           >
                             {favorites.has(show.id) ? (
                               <HeartSolidIcon className="h-5 w-5 text-red-400" />

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -108,6 +108,8 @@ export default function AudioPlayer({ show, onClose }: AudioPlayerProps) {
             <button
               onClick={togglePlayPause}
               className="p-2 bg-purple-600 hover:bg-purple-700 rounded-full transition-colors"
+              aria-label={isPlaying ? 'Pause' : 'Play'}
+              aria-pressed={isPlaying}
             >
               {isPlaying ? (
                 <PauseIcon className="h-5 w-5" />
@@ -139,7 +141,12 @@ export default function AudioPlayer({ show, onClose }: AudioPlayerProps) {
 
             {/* Volume Control */}
             <div className="flex items-center space-x-2">
-              <button onClick={toggleMute} className="p-1 hover:text-purple-300 transition-colors">
+              <button
+                onClick={toggleMute}
+                className="p-1 hover:text-purple-300 transition-colors"
+                aria-label={isMuted || volume === 0 ? 'Unmute' : 'Mute'}
+                aria-pressed={isMuted || volume === 0}
+              >
                 {isMuted || volume === 0 ? (
                   <SpeakerXMarkIcon className="h-4 w-4" />
                 ) : (
@@ -161,6 +168,7 @@ export default function AudioPlayer({ show, onClose }: AudioPlayerProps) {
             <button
               onClick={onClose}
               className="text-purple-300 hover:text-white transition-colors"
+              aria-label="Close player"
             >
               ✕
             </button>

--- a/src/components/CrowdsourceFeedback.tsx
+++ b/src/components/CrowdsourceFeedback.tsx
@@ -78,9 +78,10 @@ export default function CrowdsourceFeedback({ show, isOpen, onClose, onSubmit }:
         <div className="p-6">
           <div className="flex items-center justify-between mb-6">
             <h3 className="text-xl font-bold text-white">Help Improve Our Catalog</h3>
-            <button 
+            <button
               onClick={onClose}
               className="text-purple-300 hover:text-white transition-colors"
+              aria-label="Close feedback form"
             >
               <XMarkIcon className="h-6 w-6" />
             </button>
@@ -104,6 +105,8 @@ export default function CrowdsourceFeedback({ show, isOpen, onClose, onSubmit }:
                     type="button"
                     onClick={() => setQualityRating(rating)}
                     className="p-1 hover:scale-110 transition-transform"
+                    aria-label={`Rate ${rating} star${rating > 1 ? 's' : ''}`}
+                    aria-pressed={qualityRating >= rating}
                   >
                     {rating <= qualityRating ? (
                       <StarSolidIcon className="h-8 w-8 text-yellow-400" />


### PR DESCRIPTION
## Summary
- improve favorite toggles with aria-label and pressed state
- add aria-label/pressed to audio player controls
- label icon-only buttons in feedback form

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a1acaba3c83328f74360045b38d39