### PR TITLE
Add accessible labels to search inputs

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -126,14 +126,18 @@ export default function Home() {
           <form onSubmit={handleSearch} className="max-w-2xl mx-auto relative">
             <div className="flex items-center bg-white/10 backdrop-blur-sm rounded-xl border border-purple-500/30">
               <MagnifyingGlassIcon className="h-6 w-6 text-purple-300 ml-4" />
+              <label htmlFor="home-search" className="sr-only">
+                Search for radio dramas, series, or actors
+              </label>
               <input
+                id="home-search"
                 type="text"
                 placeholder="Search for radio dramas, series, or actors..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 className="flex-1 bg-transparent px-4 py-4 text-white placeholder-purple-300 focus:outline-none"
               />
-              <button 
+              <button
                 type="submit"
                 className="bg-purple-600 hover:bg-purple-700 px-6 py-2 m-2 rounded-lg transition-colors"
               >

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -128,7 +128,6 @@ export default function Home() {
               <MagnifyingGlassIcon className="h-6 w-6 text-purple-300 ml-4" />
               <label htmlFor="home-search" className="sr-only">
                 Search for radio dramas, series, or actors
-              </label>
               <input
                 id="home-search"
                 type="text"

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -127,7 +127,11 @@ function SearchContent() {
             <div className="flex gap-4">
               <div className="flex-1 flex items-center bg-white/10 backdrop-blur-sm rounded-xl border border-purple-500/30">
                 <MagnifyingGlassIcon className="h-6 w-6 text-purple-300 ml-4" />
+                <label htmlFor="search-input" className="sr-only">
+                  Search for radio dramas, series, or actors
+                </label>
                 <input
+                  id="search-input"
                   type="text"
                   placeholder="Search for radio dramas, series, or actors..."
                   value={query}


### PR DESCRIPTION
## Summary
- Add visually hidden labels for home and search page inputs and link them with `htmlFor`/`id`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689a1ad46bc0833281af29baa9bf6412