### PR TITLE
Add global audio player context

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import AudioPlayer from '@/components/AudioPlayer';
+import { PlayerProvider } from '@/context/PlayerContext';
 
 export const metadata: Metadata = {
   title: "Dramas.FM - Radio Drama Streaming Platform",
@@ -14,7 +16,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="font-sans antialiased">
-        {children}
+        <PlayerProvider>
+          {children}
+          <AudioPlayer />
+        </PlayerProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { usePlayer } from '@/context/PlayerContext';
 import { MagnifyingGlassIcon, PlayIcon, HeartIcon } from '@heroicons/react/24/outline';
 import { HeartIcon as HeartSolidIcon, StarIcon as StarSolidIcon } from '@heroicons/react/24/solid';
 import Link from 'next/link';
@@ -58,7 +59,7 @@ const featuredChannels = [
 export default function Home() {
   const [searchQuery, setSearchQuery] = useState('');
   const [favorites, setFavorites] = useState<Set<string>>(new Set());
-  const [currentlyPlaying, setCurrentlyPlaying] = useState<string | null>(null);
+  const { playShow, currentShow } = usePlayer();
 
   const toggleFavorite = (showId: string) => {
     const newFavorites = new Set(favorites);
@@ -75,12 +76,6 @@ export default function Home() {
     if (searchQuery.trim()) {
       window.location.href = `/search?q=${encodeURIComponent(searchQuery)}`;
     }
-  };
-
-  const playShow = (showId: string) => {
-    setCurrentlyPlaying(showId);
-    // Here we would integrate with Archive.org's audio player
-    console.log(`Playing show ${showId}`);
   };
 
   return (
@@ -167,11 +162,11 @@ export default function Home() {
                     <div className="flex items-center justify-between">
                       <div className="flex items-center space-x-3">
                         <button
-                          onClick={() => playShow(show.id)}
+                          onClick={() => playShow(show)}
                           className="flex items-center space-x-2 bg-purple-600 hover:bg-purple-700 px-4 py-2 rounded-lg transition-colors"
                         >
                           <PlayIcon className="h-4 w-4" />
-                          <span>{currentlyPlaying === show.id ? 'Playing' : 'Play'}</span>
+                          <span>{currentShow?.id === show.id ? 'Playing' : 'Play'}</span>
                         </button>
                         
                         <button

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -2,15 +2,10 @@
 
 import { useState, useRef, useEffect } from 'react';
 import { PlayIcon, PauseIcon, SpeakerWaveIcon, SpeakerXMarkIcon } from '@heroicons/react/24/outline';
-import { RadioShow } from '@/lib/types';
+import { usePlayer } from '@/context/PlayerContext';
 
-interface AudioPlayerProps {
-  show: RadioShow | null;
-  onClose: () => void;
-}
-
-export default function AudioPlayer({ show, onClose }: AudioPlayerProps) {
-  const [isPlaying, setIsPlaying] = useState(false);
+export default function AudioPlayer() {
+  const { currentShow: show, isPlaying, setIsPlaying, closePlayer } = usePlayer();
   const [currentTime, setCurrentTime] = useState(0);
   const [duration, setDuration] = useState(0);
   const [volume, setVolume] = useState(0.7);
@@ -23,25 +18,38 @@ export default function AudioPlayer({ show, onClose }: AudioPlayerProps) {
       // This is a simplified approach - in production you'd need proper Archive.org API integration
       const archiveId = show.archiveUrl.split('/').pop();
       const audioUrl = `https://archive.org/download/${archiveId}/${archiveId}.mp3`;
-      
+
       audioRef.current.src = audioUrl;
       audioRef.current.load();
     }
   }, [show]);
+
+  useEffect(() => {
+    if (!audioRef.current) return;
+    if (isPlaying) {
+      audioRef.current.play().catch(error => {
+        console.error('Error playing audio:', error);
+        window.open(show?.archiveUrl, '_blank');
+      });
+    } else {
+      audioRef.current.pause();
+    }
+  }, [isPlaying, show]);
 
   const togglePlayPause = () => {
     if (!audioRef.current) return;
 
     if (isPlaying) {
       audioRef.current.pause();
+      setIsPlaying(false);
     } else {
       audioRef.current.play().catch(error => {
         console.error('Error playing audio:', error);
         // Fallback: open Archive.org page in new tab
         window.open(show?.archiveUrl, '_blank');
       });
+      setIsPlaying(true);
     }
-    setIsPlaying(!isPlaying);
   };
 
   const handleTimeUpdate = () => {
@@ -159,7 +167,7 @@ export default function AudioPlayer({ show, onClose }: AudioPlayerProps) {
 
             {/* Close Button */}
             <button
-              onClick={onClose}
+              onClick={closePlayer}
               className="text-purple-300 hover:text-white transition-colors"
             >
               ✕

--- a/src/context/PlayerContext.tsx
+++ b/src/context/PlayerContext.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { createContext, useContext, useState, ReactNode } from 'react';
+
+export interface PlayerShow {
+  id: string;
+  title: string;
+  series: string;
+  duration: string;
+  year: string;
+  description: string;
+  archiveUrl: string;
+}
+
+interface PlayerContextType {
+  currentShow: PlayerShow | null;
+  isPlaying: boolean;
+  playShow: (show: PlayerShow) => void;
+  closePlayer: () => void;
+  setIsPlaying: (playing: boolean) => void;
+}
+
+const PlayerContext = createContext<PlayerContextType | undefined>(undefined);
+
+export function PlayerProvider({ children }: { children: ReactNode }) {
+  const [currentShow, setCurrentShow] = useState<PlayerShow | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  const playShow = (show: PlayerShow) => {
+    setCurrentShow(show);
+    setIsPlaying(true);
+  };
+
+  const closePlayer = () => {
+    setCurrentShow(null);
+    setIsPlaying(false);
+  };
+
+  return (
+    <PlayerContext.Provider value={{ currentShow, isPlaying, playShow, closePlayer, setIsPlaying }}>
+      {children}
+    </PlayerContext.Provider>
+  );
+}
+
+export function usePlayer() {
+  const context = useContext(PlayerContext);
+  if (!context) {
+    throw new Error('usePlayer must be used within PlayerProvider');
+  }
+  return context;
+}
+


### PR DESCRIPTION
## Summary
- add PlayerContext to manage globally selected show and playback state
- update home page to trigger playback via PlayerContext
- render AudioPlayer in root layout for persistent playback across routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a1b0c3a2883328b88d0b614ee5405